### PR TITLE
Add schematic file support

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
 					},
 					{
 						"filenamePattern": "*.litematic"
+					},
+					{
+						"filenamePattern": "*.schem"
 					}
 				],
 				"priority": "default"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,12 @@
 					},
 					{
 						"filenamePattern": "*.mcstructure"
+					},
+					{
+						"filenamePattern": "*.schematic"
+					},
+					{
+						"filenamePattern": "*.litematic"
 					}
 				],
 				"priority": "default"


### PR DESCRIPTION
# What's changed?

Add registration of `*.schematic` (for [WorldEdit](https://github.com/EngineHub/WorldEdit)) and `*.litematic` (for [Litematica](https://github.com/maruohon/litematica)) in `/package.json`, then users can view and edit these schematic file (also NBT file) using this plugin in VS Code by default.
