### PR TITLE
src/NbtEditor: compability with code-server

### DIFF
--- a/src/NbtEditor.ts
+++ b/src/NbtEditor.ts
@@ -187,7 +187,7 @@ export class NbtEditorProvider implements vscode.CustomEditorProvider<NbtDocumen
 					<div class="file-info"></div>
 							
 					${isStructure || isRegion ? `
-						<img class="texture-atlas" nonce="${nonce}" src="${atlasUrl}" alt="">
+						<img class="texture-atlas" nonce="${nonce}" src="${atlasUrl}" alt="" crossorigin="use-credentials">
 						<script nonce="${nonce}" src="${assetsUrl}"></script>
 						<script nonce="${nonce}" src="${uvmappingUrl}"></script>
 						<script nonce="${nonce}" src="${blocksUrl}"></script>


### PR DESCRIPTION
Encountered a `SecurityError` when calling [`atlasCtx.getImageData`](https://github.com/misode/vscode-nbt/blob/43ee1769564579f99190e7dbb313ba04f69ffe90/src/editor/ResourceManager.ts#L82), due to the canvas being tainted by a cross-origin image. As outlined in [MDN documentation](https://developer.mozilla.org/docs/Web/HTML/How_to/CORS_enabled_image), this happens even if the image server sends appropriate CORS headers — unless the `<img>` element explicitly includes the correct `crossorigin` attribute.

To resolve this, the `<img>` element used to draw the image to the canvas should include the `crossorigin` attribute. See [HTMLImageElement.crossOrigin](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/img#crossorigin) for details on valid values.