### PR TITLE
Render Bedrock .mcstructure files in the 3D structure view

### DIFF
--- a/src/NbtDocument.ts
+++ b/src/NbtDocument.ts
@@ -35,12 +35,12 @@ export class NbtDocument extends Disposable implements vscode.CustomDocument {
 		let file: NbtFile
 		try {
 			file = NbtFile.read(array, { littleEndian, bedrockHeader: littleEndian })
-			if (!littleEndian && file.root.size === 0) {
-				// if the file is empty, we try to read using little-endian
-				const bedrockFile = NbtFile.read(array, { littleEndian: true, bedrockHeader: true })
-				if (bedrockFile.root.size > 0) {
-					littleEndian = true
-					file = bedrockFile
+			if (file.root.size === 0) {
+				// if the file is empty, we try to read using the opposite endianness
+				const otherFile = NbtFile.read(array, { littleEndian: !littleEndian, bedrockHeader: !littleEndian })
+				if (otherFile.root.size > 0) {
+					littleEndian = !littleEndian
+					file = otherFile
 				}
 			}
 		} catch (e) {
@@ -88,7 +88,7 @@ export class NbtDocument extends Disposable implements vscode.CustomDocument {
 
 	public get isReadOnly() { return this._isReadOnly }
 
-	public get dataVersion() {
+	public get dataVersion(): number | undefined {
 		const file = this._documentData
 		if (file instanceof NbtRegion) {
 			const firstChunk = file.getFirstChunk()
@@ -98,6 +98,9 @@ export class NbtDocument extends Disposable implements vscode.CustomDocument {
 			// should be 1.12 but mcmeta doesn't have that, so using 1.14
 			// TODO: handle {Materials:"Pocket"} differently
 			return 1952
+		} else if (file.root.hasCompound('structure')) {
+			// bedrock mcstructure files don't have DataVersion, use the latest release instead
+			return undefined
 		} else {
 			return file.root.getNumber('DataVersion') ?? 0
 		}
@@ -157,6 +160,9 @@ export class NbtDocument extends Disposable implements vscode.CustomDocument {
 		const root = this._documentData.root
 		if (root.hasList('size', NbtType.Int, 3) && root.hasList('blocks') && root.hasList('palette')) {
 			return true // vanilla structure
+		}
+		if (root.hasList('size', NbtType.Int, 3) && root.hasCompound('structure')) {
+			return true // bedrock mcstructure
 		}
 		return false // anything else
 	}

--- a/src/editor/Schematics.ts
+++ b/src/editor/Schematics.ts
@@ -158,6 +158,55 @@ export function litematicToStructure(root: NbtCompound) {
 	return new MultiStructure([width, height, length], regions)
 }
 
+export function mcstructureToStructure(root: NbtCompound) {
+	const [width, height, length] = root.getList('size', NbtType.Int).map(e => e.getAsNumber())
+
+	const structureCompound = root.getCompound('structure')
+	const paletteCompound = structureCompound.getCompound('palette')
+	const defaultKey = paletteCompound.hasCompound('default') ? 'default' : [...paletteCompound.keys()][0]
+	const defaultPalette = paletteCompound.getCompound(defaultKey)
+
+	const palette: BlockState[] = defaultPalette.getList('block_palette', NbtType.Compound).map(entry => {
+		const name = entry.getString('name')
+		const properties: Record<string, string> = {}
+		entry.getCompound('states').forEach((key, tag) => {
+			if (tag.isByte()) {
+				properties[key] = tag.getAsNumber() === 0 ? 'false' : 'true'
+			} else if (tag.isString()) {
+				properties[key] = tag.getAsString()
+			} else {
+				properties[key] = String(tag.getAsNumber())
+			}
+		})
+		return new BlockState(name, properties)
+	})
+
+	const blockPositionData = defaultPalette.getCompound('block_position_data')
+
+	const indices = structureCompound.getList('block_indices', NbtType.List).getList(0, NbtType.Int).map(e => e.getAsNumber())
+
+	const blocks: { pos: BlockPos, state: number, nbt?: NbtCompound }[] = []
+	for (let x = 0; x < width; x += 1) {
+		for (let y = 0; y < height; y += 1) {
+			for (let z = 0; z < length; z += 1) {
+				const i = (x * height + y) * length + z
+				const state = indices[i]
+				if (state === undefined || state === -1) continue
+				if (state > palette.length - 1) {
+					console.error(`Invalid palette ID ${state}`)
+					continue
+				}
+				const blockData = blockPositionData.hasCompound(String(i)) ? blockPositionData.getCompound(String(i)) : undefined
+				const blockEntityTag = blockData?.hasCompound('block_entity_data') ? blockData.getCompound('block_entity_data') : undefined
+				const nbt = blockEntityTag ? NbtCompound.fromJson(blockEntityTag.toJson()) : undefined
+				blocks.push({ pos: [x, y, z], state, nbt })
+			}
+		}
+	}
+
+	return new Structure([width, height, length], palette, blocks)
+}
+
 export function schematicToStructure(root: NbtCompound) {
 	const width = root.getNumber('Width')
 	const height = root.getNumber('Height')

--- a/src/editor/StructureEditor.ts
+++ b/src/editor/StructureEditor.ts
@@ -6,7 +6,7 @@ import type { NbtEdit } from '../common/types'
 import type { EditHandler, EditorPanel, VSCode } from './Editor'
 import { locale } from './Locale'
 import { ResourceManager } from './ResourceManager'
-import { litematicToStructure, schematicToStructure, spongeToStructure } from './Schematics'
+import { litematicToStructure, mcstructureToStructure, schematicToStructure, spongeToStructure } from './Schematics'
 import { TreeEditor } from './TreeEditor'
 import { clamp, clampVec3, negVec3 } from './Util'
 
@@ -268,6 +268,9 @@ export class StructureEditor implements EditorPanel {
 		if (this.file.root.get('Blocks')?.isByteArray() && this.file.root.get('Data')?.isByteArray()) {
 			return schematicToStructure(this.file.root)
 		}
+		if (this.file.root.hasCompound('structure') && this.file.root.hasList('size', NbtType.Int, 3)) {
+			return mcstructureToStructure(this.file.root)
+		}
 		return Structure.fromNbt(this.file.root)
 	}
 
@@ -334,7 +337,7 @@ export class StructureEditor implements EditorPanel {
 		this.root.querySelector('.side-panel')?.remove()
 		const block = this.selectedBlock ? this.structure.getBlock(this.selectedBlock) : null
 
-		const readOnly = this.readOnly || !this.file.root.hasList('size', NbtType.Int, 3)
+		const readOnly = this.readOnly || !this.file.root.hasList('size', NbtType.Int, 3) || this.file.root.hasCompound('structure')
 
 		const sidePanel = document.createElement('div')
 		sidePanel.classList.add('side-panel')


### PR DESCRIPTION
Bedrock .mcstructure files were already being parsed correctly (little endian, gzip/zlib detection is handled by deepslate), but the editor treated them as generic NBT, so they only showed up in the tree view. This adds proper support for viewing them in 3D.

Changes:

- `NbtDocument.isStructureData()` now recogn with a `size` int list and a `structure` compound), so the structure panel is offered for these files.
- New `mcstructureToStructure()` in `Schematformat to a deepslate `Structure`: palette from `structure.palette.default.block_palette` (byte states become "true"/"false", everything else is passed through), blocks from layer 0 of `block_indices` using the Bedrock index order (x outermost, z innermost), -1 entries skipped, block entities attached from `block_position_data`.
- `dataVersion` returns undefined for Bedrock files so the latest release assets are used instead of the 1.18.2 fallback.
- The empty-root endianness retry in `readFile()` now works in both directions instead of only when starting from big end
- The side panel is read-only for Bedrock files, since the existing edit paths assume the Java structure layout and would

Known limitations, matching what the other schematic formats do: no mapping of Bedrock block states to Java ones (blocks with unrecognized states render with their default variant), and the waterlogging layer and entities are ignored.

Tested with structures exported from Bedrocked, plus a Java structure renamed to .mcstructure to check the endianness fallback.